### PR TITLE
Turned off GT ore unifying to prevent NBT issues.

### DIFF
--- a/BR1710/config/GregTech/GregTech.cfg
+++ b/BR1710/config/GregTech/GregTech.cfg
@@ -25,7 +25,7 @@ general {
     I:FlintAndSteelChance=30
     B:HardCoreCableLoss=false
     B:IncreaseDungeonLoot=false
-    B:InventoryUnification=true
+    B:InventoryUnification=false
     I:ItemDespawnTime=6000
     B:LoggingPlayerActivity=true
     I:MillisecondsPassedInGTTileEntityUntilLagWarning=100


### PR DESCRIPTION
Some players have problems with blocks and items not stacking due to this bug, and it is reported to Greg afaik.
