### PR TITLE
Fix #291

### DIFF
--- a/BR1710/config/enderio/OreDictionaryPreferences_User.xml
+++ b/BR1710/config/enderio/OreDictionaryPreferences_User.xml
@@ -2,4 +2,10 @@
 Entries in this file take precedence over the values in the core file
  -->
 <OreDictionaryPreferences>
+  <preference oreDictionary="sand" >
+    <itemStack modID="minecraft" itemName="sand" itemMeta="0" />
+  </preference>
+  <preference oreDictionary="gravel" >
+    <itemStack modID="minecraft" itemName="gravel" itemMeta="0" />
+  </preference>
 </OreDictionaryPreferences>


### PR DESCRIPTION
BR 2.3.4 EIO SagMill output wrong items #291
Also mentioned:
https://github.com/SleepyTrousers/EnderIO/issues/2751
Adaptation from Fix: https://github.com/mmelvin0/EnderIO/commit/f9a7aefbbac00c53cc074b7fbe3af7bdc020ca07