### PR TITLE
Added assembler recipes for ender io capacitors

### DIFF
--- a/BR1710/scripts/EnderIO.zs
+++ b/BR1710/scripts/EnderIO.zs
@@ -19,3 +19,23 @@ recipes.remove(<EnderIO:itemMachinePart>);
 recipes.addShaped(<EnderIO:itemMachinePart>, [[bars, steelplate, bars],
                                                     [steelplate, basic, steelplate],
                                                     [bars, steelplate, bars]]);			
+                                                    
+val goldWire2x = <gregtech:gt.blockmachines:1421>;
+val copperPlate = <Railcraft:part.plate:3>;
+val coalPlate = <gregtech:gt.metaitem.01:17535>;
+val glowstone = <minecraft:glowstone>;
+val redstoneLiquid = <liquid:molten.redstone>;
+val energeticLiquid = <liquid:molten.energeticalloy>;
+val vibrantLiquid = <liquid:molten.vibrantalloy>;
+val adv = <EnderIO:itemBasicCapacitor:1>;
+val elite = <EnderIO:itemBasicCapacitor:2>;
+
+val timeinS = 3; // May need to be changed for balancing
+val t1eu = 32;
+
+//Assembler recipes for ender io components
+mods.gregtech.AssemblerLiq.addRecipe(basic, goldWire2x * 4, copperPlate, redstoneLiquid * 288, timeinS * 20, t1eu );
+
+mods.gregtech.AssemblerLiq.addRecipe(adv, basic * 2, coalPlate, energeticLiquid * 864, timeinS * 20 * 2, t1eu * 4 );
+
+mods.gregtech.AssemblerLiq.addRecipe(elite, adv * 2, glowstone, vibrantLiquid * 864, timeinS * 20 * 4, t1eu * 16 );	                                                    


### PR DESCRIPTION
I looked at adding recipes for gregtech machine for use in other mods.

However, a lot of the machines need a newer version of minetweaker and gttweaker to be used.

For example, the version we have is using the 'AssemblerLig' class instead of the 'Assembler' class that the wiki references.