### PR TITLE
Forestry Backpack fix

### DIFF
--- a/BR1710/config/forestry/backpacks.cfg
+++ b/BR1710/config/forestry/backpacks.cfg
@@ -3,41 +3,8 @@
 backpacks {
 
     miner {
-        S:item.stacks <
-            Railcraft:cube:0
-            Railcraft:cube:10
-            Railcraft:cube:11
-            Railcraft:cube:2
-            Railcraft:cube:9
-            Railcraft:dust:0
-            Railcraft:dust:1
-            Railcraft:dust:2
-            Railcraft:dust:3
-            Railcraft:ingot:0
-            Railcraft:ingot:1
-            Railcraft:ingot:2
-            Railcraft:ingot:3
-            Railcraft:nugget:0
-            Railcraft:nugget:1
-            Railcraft:nugget:2
-            Railcraft:nugget:3
-            Railcraft:nugget:4
-            Railcraft:ore:0
-            Railcraft:ore:1
-            Railcraft:ore:10
-            Railcraft:ore:11
-            Railcraft:ore:2
-            Railcraft:ore:3
-            Railcraft:ore:4
-            Railcraft:ore:5
-            Railcraft:ore:6
-            Railcraft:ore:7
-            Railcraft:ore:8
-            Railcraft:ore:9
-         >
-
         # Add itemStacks for the miner's backpack here in the format 'modid:name:meta'. For wildcard metadata the format is 'modid:name'.
-        S:itemStacks <
+        S:item.stacks <
             Forestry:brokenBronzePickaxe:0
             Forestry:bronzePickaxe:0
             Forestry:kitPickaxe:0
@@ -75,11 +42,9 @@ backpacks {
             minecraft:coal_ore:0
             minecraft:obsidian:0
          >
-        S:ore.dict <
-         >
-
+         
         # Add ore dictionary names for the miner's backpack here in the format 'oreDictName'.
-        S:oreDict <
+        S:ore.dict <
             clusterAdamantine
             clusterAlduorite
             clusterAluminum
@@ -4544,18 +4509,8 @@ backpacks {
     }
 
     digger {
-        S:item.stacks <
-            Railcraft:cube:6
-            Railcraft:cube:7
-            chisel:andesite:0
-            chisel:diorite:0
-            chisel:granite:0
-            chisel:limestone:0
-            chisel:marble:0
-         >
-
         # Add itemStacks for the digger's backpack here in the format 'modid:name:meta'. For wildcard metadata the format is 'modid:name'.
-        S:itemStacks <
+        S:item.stacks <
             Forestry:brokenBronzeShovel:0
             Forestry:bronzeShovel:0
             Forestry:kitShovel:0
@@ -4574,11 +4529,9 @@ backpacks {
             minecraft:sandstone:0
             minecraft:soul_sand:0
          >
-        S:ore.dict <
-         >
-
+        
         # Add ore dictionary names for the digger's backpack here in the format 'oreDictName'.
-        S:oreDict <
+        S:ore.dict <
             cobblestone
             sand
             stone
@@ -4632,15 +4585,8 @@ backpacks {
     }
 
     forester {
-        S:item.stacks <
-            IC2:blockRubLeaves:0
-            IC2:blockRubSapling:0
-            IC2:itemHarz:0
-            IC2:itemRubber:0
-         >
-
         # Add itemStacks for the forester's backpack here in the format 'modid:name:meta'. For wildcard metadata the format is 'modid:name'.
-        S:itemStacks <
+        S:item.stacks <
             IC2:blockRubLeaves:0
             IC2:blockRubSapling:0
             IC2:itemHarz:0
@@ -4659,12 +4605,11 @@ backpacks {
             minecraft:vine:0
             minecraft:yellow_flower:0
          >
-        S:ore.dict <
-         >
-
+        
         # Add ore dictionary names for the forester's backpack here in the format 'oreDictName'.
-        S:oreDict <
+        S:ore.dict <
             cropASparagus
+            cropAsparagus
             cropAlmond
             cropApple
             cropApricot
@@ -4837,11 +4782,8 @@ backpacks {
     }
 
     hunter {
-        S:item.stacks <
-         >
-
         # Add itemStacks for the hunter's backpack here in the format 'modid:name:meta'. For wildcard metadata the format is 'modid:name'.
-        S:itemStacks <
+        S:item.stacks <
             minecraft:arrow:0
             minecraft:beef:0
             minecraft:blaze_powder:0
@@ -4880,176 +4822,25 @@ backpacks {
             minecraft:string:0
             minecraft:wool
          >
-        S:ore.dict <
-         >
-
+        
         # Add ore dictionary names for the hunter's backpack here in the format 'oreDictName'.
-        S:oreDict <
+        S:ore.dict <
          >
     }
 
     adventurer {
+        # Add itemStacks for the adventurer's backpack here in the format 'modid:name:meta'. For wildcard metadata the format is 'modid:name'.
         S:item.stacks <
          >
 
-        # Add itemStacks for the adventurer's backpack here in the format 'modid:name:meta'. For wildcard metadata the format is 'modid:name'.
-        S:itemStacks <
-         >
-        S:ore.dict <
-         >
-
         # Add ore dictionary names for the adventurer's backpack here in the format 'oreDictName'.
-        S:oreDict <
+        S:ore.dict <
          >
     }
 
     builder {
-        S:item.stacks <
-            Railcraft:anvil
-            Railcraft:brick.abyssal
-            Railcraft:brick.bleachedbone
-            Railcraft:brick.bloodstained
-            Railcraft:brick.frostbound
-            Railcraft:brick.infernal
-            Railcraft:brick.nether
-            Railcraft:brick.quarried
-            Railcraft:brick.sandy
-            Railcraft:cube:1
-            Railcraft:cube:8
-            Railcraft:frame
-            Railcraft:glass
-            Railcraft:lantern.metal:0
-            Railcraft:lantern.metal:1
-            Railcraft:lantern.metal:2
-            Railcraft:lantern.metal:3
-            Railcraft:lantern.metal:4
-            Railcraft:lantern.metal:5
-            Railcraft:lantern.stone:0
-            Railcraft:lantern.stone:1
-            Railcraft:lantern.stone:2
-            Railcraft:lantern.stone:3
-            Railcraft:lantern.stone:4
-            Railcraft:lantern.stone:5
-            Railcraft:lantern.stone:6
-            Railcraft:lantern.stone:7
-            Railcraft:lantern.stone:8
-            Railcraft:lantern.stone:9
-            Railcraft:post
-            Railcraft:post.metal
-            Railcraft:post.metal.platform
-            Railcraft:slab:0
-            Railcraft:slab:1
-            Railcraft:slab:10
-            Railcraft:slab:11
-            Railcraft:slab:12
-            Railcraft:slab:13
-            Railcraft:slab:14
-            Railcraft:slab:15
-            Railcraft:slab:16
-            Railcraft:slab:17
-            Railcraft:slab:18
-            Railcraft:slab:19
-            Railcraft:slab:2
-            Railcraft:slab:20
-            Railcraft:slab:21
-            Railcraft:slab:22
-            Railcraft:slab:23
-            Railcraft:slab:24
-            Railcraft:slab:25
-            Railcraft:slab:26
-            Railcraft:slab:27
-            Railcraft:slab:28
-            Railcraft:slab:29
-            Railcraft:slab:30
-            Railcraft:slab:31
-            Railcraft:slab:32
-            Railcraft:slab:33
-            Railcraft:slab:34
-            Railcraft:slab:35
-            Railcraft:slab:36
-            Railcraft:slab:37
-            Railcraft:slab:38
-            Railcraft:slab:39
-            Railcraft:slab:40
-            Railcraft:slab:41
-            Railcraft:slab:42
-            Railcraft:slab:43
-            Railcraft:slab:5
-            Railcraft:slab:6
-            Railcraft:slab:7
-            Railcraft:slab:8
-            Railcraft:slab:9
-            Railcraft:stair:0
-            Railcraft:stair:1
-            Railcraft:stair:10
-            Railcraft:stair:11
-            Railcraft:stair:12
-            Railcraft:stair:13
-            Railcraft:stair:14
-            Railcraft:stair:15
-            Railcraft:stair:16
-            Railcraft:stair:17
-            Railcraft:stair:18
-            Railcraft:stair:19
-            Railcraft:stair:2
-            Railcraft:stair:20
-            Railcraft:stair:21
-            Railcraft:stair:22
-            Railcraft:stair:23
-            Railcraft:stair:24
-            Railcraft:stair:25
-            Railcraft:stair:26
-            Railcraft:stair:27
-            Railcraft:stair:28
-            Railcraft:stair:29
-            Railcraft:stair:30
-            Railcraft:stair:31
-            Railcraft:stair:32
-            Railcraft:stair:33
-            Railcraft:stair:34
-            Railcraft:stair:35
-            Railcraft:stair:36
-            Railcraft:stair:37
-            Railcraft:stair:38
-            Railcraft:stair:39
-            Railcraft:stair:40
-            Railcraft:stair:41
-            Railcraft:stair:42
-            Railcraft:stair:43
-            Railcraft:stair:5
-            Railcraft:stair:6
-            Railcraft:stair:7
-            Railcraft:stair:8
-            Railcraft:stair:9
-            Railcraft:wall.alpha:0
-            Railcraft:wall.alpha:1
-            Railcraft:wall.alpha:10
-            Railcraft:wall.alpha:11
-            Railcraft:wall.alpha:12
-            Railcraft:wall.alpha:13
-            Railcraft:wall.alpha:14
-            Railcraft:wall.alpha:15
-            Railcraft:wall.alpha:2
-            Railcraft:wall.alpha:3
-            Railcraft:wall.alpha:4
-            Railcraft:wall.alpha:5
-            Railcraft:wall.alpha:6
-            Railcraft:wall.alpha:7
-            Railcraft:wall.alpha:8
-            Railcraft:wall.alpha:9
-            Railcraft:wall.beta:0
-            Railcraft:wall.beta:1
-            Railcraft:wall.beta:2
-            Railcraft:wall.beta:3
-            Railcraft:wall.beta:4
-            Railcraft:wall.beta:5
-            Railcraft:wall.beta:6
-            Railcraft:wall.beta:7
-            Railcraft:wall.beta:8
-         >
-
         # Add itemStacks for the builder's backpack here in the format 'modid:name:meta'. For wildcard metadata the format is 'modid:name'.
-        S:itemStacks <
+        S:item.stacks <
             Forestry:candle
             Forestry:stump
             Railcraft:anvil
@@ -5216,11 +5007,9 @@ backpacks {
             minecraft:stonebrick
             minecraft:torch:0
          >
-        S:ore.dict <
-         >
-
+        
         # Add ore dictionary names for the builder's backpack here in the format 'oreDictName'.
-        S:oreDict <
+        S:ore.dict <
             blockAluminium
             blockAndesite
             blockAnnealedCopper


### PR DESCRIPTION
Update of Forestry (from v3 to v4) has converted Backpacks.cfg file. Unfortunately it put already specified items under incorrect groups. Moved the entries from itemStacks => item.stacks and from oreDict => ore.dict fixes it and items can be again put into the backpacks. https://github.com/Beyond-Reality/BeyondRealityModPack/issues/329#issuecomment-151218068