### PR TITLE
Update forestry.zs

### DIFF
--- a/BR1710/scripts/forestry.zs
+++ b/BR1710/scripts/forestry.zs
@@ -115,3 +115,17 @@ for woodType, coverID in coverGTForestryWoods
   CuttingSaw.addRecipe([cover * 2], slabWoodFireproof, distilledWater, 100, 8);
   CuttingSaw.addRecipe([cover * 2], slabWoodFireproof, lubricant, 40, 8);
 }
+
+//Remove Forestry Gears
+
+val TinGear = <ore:gearTin>;
+val CopperGear = <ore:gearCopper>;
+val BronzeGear = <ore:gearBronze>;
+
+
+TinGear.remove(<Forestry:gearTin>);
+recipes.remove(<Forestry:gearTin>);
+CopperGear.remove(<Forestry:gearCopper>);
+recipes.remove(<Forestry:gearCopper>);
+BronzeGear.remove(<Forestry:gearBronze>);
+recipes.remove(<Forestry:gearBronze>);


### PR DESCRIPTION
Removes Foresty Gears.   All Forestry recipes use OreDict entries for gears, so they will now require GregTech variants in the valid recipes.