### PR TITLE
Fix #447

### DIFF
--- a/BR1710/config/GregTech/Unification.cfg
+++ b/BR1710/config/GregTech/Unification.cfg
@@ -4362,8 +4362,8 @@ specialunificationtargets {
 
     minefactoryreloaded {
         B:dustPlastic_false=false
-        B:ingotMeatRaw_false=false
-        B:nuggetMeatRaw_false=false
+        B:ingotMeatRaw_false=true
+        B:nuggetMeatRaw_false=true
     }
 
     ihl {

--- a/BR1710/scripts/MFR.zs
+++ b/BR1710/scripts/MFR.zs
@@ -16,6 +16,7 @@ val nuggetMeatCooked = <MineFactoryReloaded:meat.nugget.cooked>;
 val nuggetMeatRaw = <MineFactoryReloaded:meat.nugget.raw>;
 val blockMeatCooked = <MineFactoryReloaded:brick:13>;
 val blockMeatRaw = <MineFactoryReloaded:brick:12>;
+val ingotMeatCookedGT = <gregtech:gt.metaitem.01:11893>;
 
 # MFR Changes
 
@@ -28,6 +29,7 @@ val blockMeatRaw = <MineFactoryReloaded:brick:12>;
 <ore:ingotMeatCooked>.remove(ingotMeatRaw);
 <ore:nuggetMeatCooked>.remove(nuggetMeatRaw);
 <ore:blockMeatCooked>.remove(blockMeatRaw);
+furnace.remove(ingotMeatCookedGT);
 
 # Disable RedNet Energy Cable
 recipes.remove(redstonecable);


### PR DESCRIPTION
Removes meat into meat ingot smelting and disables unification for meat ingot