### PR TITLE
Add ExtraUtils & AE2 glass to sealable blocks

### DIFF
--- a/BR1710/config/Galacticraft/core.conf
+++ b/BR1710/config/Galacticraft/core.conf
@@ -241,6 +241,26 @@ general {
         Railcraft:glass:13
         Railcraft:glass:14
         Railcraft:glass:15
+        ExtraUtilities:decorativeBlock2
+        ExtraUtilities:decorativeBlock2:1
+        ExtraUtilities:decorativeBlock2:2
+        ExtraUtilities:decorativeBlock2:3
+        ExtraUtilities:decorativeBlock2:4
+        ExtraUtilities:decorativeBlock2:5
+        ExtraUtilities:decorativeBlock2:6
+        ExtraUtilities:decorativeBlock2:7
+        ExtraUtilities:decorativeBlock2:8
+        ExtraUtilities:decorativeBlock2:9
+        ExtraUtilities:decorativeBlock2:10
+        ExtraUtilities:decorativeBlock2:11
+        ExtraUtilities:etherealglass
+        ExtraUtilities:etherealglass:1
+        ExtraUtilities:etherealglass:2
+        ExtraUtilities:etherealglass:3
+        ExtraUtilities:etherealglass:4
+        ExtraUtilities:etherealglass:5
+        appliedenergistics2:tile.BlockQuartzGlass
+        appliedenergistics2:tile.BlockQuartzLamp
      >
 
     # List blocks from other mods that the Sensor Glasses should recognize as solid blocks. Format is BlockName or BlockName:metadata.


### PR DESCRIPTION
Add ExtraUtilities decorative and ethereal glass, and AE2 quartz glass to sealable blocks.