### PR TITLE
GT-gated TT's KAMI

### DIFF
--- a/BR1710/config/ThaumicTinkerer.cfg
+++ b/BR1710/config/ThaumicTinkerer.cfg
@@ -33,6 +33,7 @@ enchantments {
 
 
 general {
+    # The number of verticle veins of ore per chunk. Default: 1
     I:"Bedrock Dimension ore density"=1
 
     # Allows crops to be grown using bonemeal. Useful for debug purposes.
@@ -46,7 +47,7 @@ general {
     B:imbuedFire.enabled=false
 
     # Set to true to enable all kami stuff (note, either this OR the kami mod file will work)
-    B:kami.forceenabled=false
+    B:kami.forceenabled=true
 
     # Set to true to enable flight in this mod.
     B:modFlight.enabled=true
@@ -73,12 +74,21 @@ general {
     ##########################################################################################################
 
     kami {
+        # Set to the dimension id wished for bedrock dimension, or 0 to disable
         I:"Bedrock dimension id"=-47
+
+        # These ores will not be spawned in the bedrock dimension
         S:"Bedrock dimension ore Blacklist" <
             oreFirestone
          >
+
+        # The Dimension ID for the End, leave at 1 if you don't modify it with another mod/plugin.
         I:dimension.end.id=1
+
+        # The Dimension ID for the Nether, leave at -1 if you don't modify it with another mod/plugin.
         I:dimension.nether.id=-1
+
+        # Set to false to remove the phantom blocks displayed by the Worldshaper's Seeing Glass.
         B:placementMirror.blocks.show=true
     }
 

--- a/BR1710/scripts/Thaumcraft.zs
+++ b/BR1710/scripts/Thaumcraft.zs
@@ -1,6 +1,7 @@
 # Thaumcraft.zs tweaks
 import mods.thaumcraft.Crucible;
 import mods.thaumcraft.Infusion;
+import mods.thaumcraft.Arcane;
 
 // Fix crafting with Gregtech blockThaumium
 val golemThaumium = <Thaumcraft:ItemGolemPlacer:7>;
@@ -38,3 +39,71 @@ for blockThaumium in <ore:blockThaumium>.items {
   );
 
 }
+
+
+// Make KAMI awakened tools, armour and wand harder to obtain using ichorium ingot as a gate
+val ingotTritainium =  <gregtech:gt.metaitem.01:11329>;
+val ichor = <ThaumicTinkerer:kamiResource>;
+val ichorCloth = <ThaumicTinkerer:kamiResource:1>;
+val ichoriumIngot = <ThaumicTinkerer:kamiResource:2>;
+val exDiamond = <ore:gemExquisiteDiamond>;
+val salisMundus = <Thaumcraft:ItemResource:14>;
+val silverwoodRod = <Thaumcraft:WandRod:2>;
+val ichorRod = <ThaumicTinkerer:kamiResource:5>;
+
+mods.thaumcraft.Arcane.removeRecipe(ichoriumIngot);
+mods.thaumcraft.Arcane.addShaped(
+   "ICHORIUM", ichoriumIngot,
+   "ignis 100, terra 100, aqua 100, aer 100, ordo 100, perditio 100",
+   [[null, ingotTritainium, null], 
+    [ichor, exDiamond, ichor],
+    [null, ichor, null]]
+);
+mods.thaumcraft.Research.refreshResearchRecipe("ICHORIUM");
+
+Infusion.removeRecipe(ichorRod);
+mods.thaumcraft.Infusion.addRecipe(
+  "ROD_ICHORCLOTH", silverwoodRod, [
+   ichoriumIngot,
+   ichorCloth,
+   salisMundus, <minecraft:ghast_tear>, salisMundus,
+   ichorCloth
+  ],
+  "instrumentum 64, lux 64, praecantatio 150",
+  ichorRod, 10
+);
+mods.thaumcraft.Research.refreshResearchRecipe("ROD_ICHORCLOTH");
+
+mods.thaumcraft.Arcane.removeRecipe(<ThaumicTinkerer:ichorclothHelm>);
+mods.thaumcraft.Arcane.addShaped(
+   "ICHORCLOTH_ARMOR", <ThaumicTinkerer:ichorclothHelm>,
+   "aqua 75",
+   [[ichoriumIngot, ichorCloth, ichoriumIngot], 
+    [ichorCloth, null, ichorCloth],
+    [null, null, null]]
+);
+mods.thaumcraft.Arcane.removeRecipe(<ThaumicTinkerer:ichorclothChest>);
+mods.thaumcraft.Arcane.addShaped(
+   "ICHORCLOTH_ARMOR", <ThaumicTinkerer:ichorclothChest>,
+   "aer 75",
+   [[ichorCloth, null, ichorCloth], 
+    [ichoriumIngot, ichorCloth, ichoriumIngot],
+    [ichorCloth, ichorCloth, ichorCloth]]
+);
+mods.thaumcraft.Arcane.removeRecipe(<ThaumicTinkerer:ichorclothLegs>);
+mods.thaumcraft.Arcane.addShaped(
+   "ICHORCLOTH_ARMOR", <ThaumicTinkerer:ichorclothLegs>,
+   "ignis 75",
+   [[ichorCloth, ichorCloth, ichorCloth], 
+    [ichoriumIngot, null, ichoriumIngot],
+    [ichorCloth, null, ichorCloth]]
+);
+mods.thaumcraft.Arcane.removeRecipe(<ThaumicTinkerer:ichorclothBoots>);
+mods.thaumcraft.Arcane.addShaped(
+   "ICHORCLOTH_ARMOR", <ThaumicTinkerer:ichorclothBoots>,
+   "terra 75",
+   [[ichorCloth, null, ichorCloth], 
+    [ichoriumIngot, null, ichoriumIngot],
+    [null, null, null]]
+);
+mods.thaumcraft.Research.refreshResearchRecipe("ICHORCLOTH_ARMOR");


### PR DESCRIPTION
Re-enabled Thaumic Tinkerer's KAMI but gated the OP items (awakened tools, infused ichorcloth armour, ichor wand and ichor wand caps) behind GT tritainium by requiring it for ichorium ingots. To gate the armour and rod, ichorium ingots were added to those recipes.

Tritainium seemed a good choice since those tools/armour pieces are indestructible.

This leaves the rest of TT KAMI accessible as normal while restricting those extreme items until the late end-game.