### PR TITLE
Make Witching Gadgets Cloak of the Wolf harder to obtain

### DIFF
--- a/BR1710/scripts/Thaumcraft.zs
+++ b/BR1710/scripts/Thaumcraft.zs
@@ -107,3 +107,28 @@ mods.thaumcraft.Arcane.addShaped(
     [null, null, null]]
 );
 mods.thaumcraft.Research.refreshResearchRecipe("ICHORCLOTH_ARMOR");
+
+
+// Make Witching Gadgets wolven cloak harder to obtain (it provides speed+strength+resistance II, III then IV
+// when being repeatedly hit making the player near invulnerable against groups of regular mobs)
+
+val baseCloak = <ore:travelgearCloakBase>;
+val voidIngot = <ore:ingotVoidMetal>;
+val wolfPelt = <WitchingGadgets:item.WG_Material:6>;
+val metSteelRing = <ore:ringMeteoricSteel>;
+val strFlask = <Botania:brewFlask>.withTag({brewKey: "strength"});
+val resFlask = <Botania:brewFlask>.withTag({brewKey: "resistance"});
+val spdFlask = <Botania:brewFlask>.withTag({brewKey: "speed"});
+
+mods.thaumcraft.Arcane.removeRecipe(<WitchingGadgets:item.WG_Cloak:3>);
+mods.thaumcraft.Arcane.addShaped(
+   "CLOAK_WOLF", <WitchingGadgets:item.WG_Cloak:3>,
+   "perditio 100, terra 75, ignis 50",
+   [[metSteelRing, voidIngot, metSteelRing], 
+    [wolfPelt, baseCloak, wolfPelt],
+    [strFlask, resFlask, spdFlask]]
+);
+mods.thaumcraft.Research.refreshResearchRecipe("CLOAK_WOLF");
+
+
+


### PR DESCRIPTION
WG's cloak of the wolf is somewhat overpowered. On repeated hits it gives the wearer speed, strength and resistance IV.

I tested it with 8 HEE angry endermen and 10 TC angry zombies in a confined space wearing prot IV diamond armour. With the cloak after 30 seconds they had knocked off 4 hearts. Without the cloak I was dead in under 6 seconds.

To redress the balance I propose requiring voidmetal, meteoric steel (ie. a trip to the moon and an EBF) and the appropriate Botania flasks (ie. the elven gateway stage of Botania - they need alfglass). This will make the item very much mid-game at the earliest.

